### PR TITLE
[Feat] Add Village Fetching with Pagination

### DIFF
--- a/controllers/VillageController.js
+++ b/controllers/VillageController.js
@@ -1,0 +1,31 @@
+const Village = require("../models/Village");
+
+class VillageController {
+  async findAll(req, res) {
+    try {
+      const { page } = req.query;
+      const limit = 6;
+      const offset = (parseInt(page) - 1) * limit;
+
+      const result = await Village.findAndCountAll({
+        limit: limit,
+        offset: offset,
+        order: [["name", "ASC"]],
+      });
+
+      const totalPages = Math.ceil(result.count / limit);
+
+      return res.status(200).json({
+        totalRecords: result.count,
+        totalPages: totalPages,
+        currentPage: page,
+        data: result.rows,
+      });
+    } catch (error) {
+      console.log(error);
+      return res.status(500).json({ error: "Error finding all villages" });
+    }
+  }
+}
+
+module.exports = new VillageController();

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const database = require("./config/database");
 const characterRoutes = require("./routes/characterRoutes");
+const villageRoutes = require("./routes/villageRoutes");
 const cors = require("cors");
 
 const app = express();
@@ -9,6 +10,7 @@ const port = 3000;
 app.use(express.json());
 app.use(cors());
 app.use(characterRoutes);
+app.use(villageRoutes);
 
 app.listen(port, async () => {
   await database.connect();

--- a/migrations/20250303225455-create-village.js
+++ b/migrations/20250303225455-create-village.js
@@ -1,0 +1,37 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable("Villages", {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER,
+      },
+      name: {
+        type: Sequelize.STRING,
+      },
+      about: {
+        type: Sequelize.TEXT,
+      },
+      url: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable("Villages");
+  },
+};

--- a/models/Village.js
+++ b/models/Village.js
@@ -1,0 +1,32 @@
+const { Model, DataTypes } = require("sequelize");
+const database = require("../config/database").sequelize;
+
+class Village extends Model {}
+
+Village.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    about: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    url: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize: database,
+    modelName: "Village",
+  }
+);
+
+module.exports = Village;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "naruto-classic-wiki-api",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "naruto-classic-wiki-api",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "naruto-classic-wiki-api",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "naruto-classic-wiki-api",
   "main": "index.js",
   "scripts": {

--- a/routes/villageRoutes.js
+++ b/routes/villageRoutes.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const VillageController = require("../controllers/VillageController");
+
+const router = express.Router();
+
+router.get("/villages", VillageController.findAll);
+
+module.exports = router;

--- a/seeders/20250303230035-village-seed.js
+++ b/seeders/20250303230035-village-seed.js
@@ -1,0 +1,59 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.bulkInsert(
+      "Villages",
+      [
+        {
+          name: "Hidden Leaf Village (Konohagakure) ",
+          about: "Konohagakure is one of the Five Great Shinobi Villages and the home of many main characters in the series. It was founded by Hashirama Senju and Madara Uchiha and values the spirit of teamwork and the Will of Fire, a philosophy that encourages ninjas to protect their comrades and their home at any cost. It is known for housing the Uchiha, Hyūga, and other powerful clans.",
+          url: "https://pm1.aminoapps.com/6422/1c6472bef8b560cfdd54c8da24e0e8d701e1c04f_hq.jpg",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          name: "Hidden Sand Village (Sunagakure)",
+          about: "Located in the arid desert of the Land of Wind, Sunagakure is famous for its ninjas skilled in sand manipulation and puppetry. Throughout the series, the village faces economic difficulties due to the country's government, leading to internal tensions. Its leader, the Kazekage, controls the village, and one of its most notable ninjas is Gaara, who becomes one of the strongest Kazekages in history.",
+          url: "https://pm1.aminoapps.com/6328/7b31073f420ca52c3f55404a76926cea61b95bf6_hq.jpg",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          name: "Hidden Mist Village (Kirigakure)",
+          about: "Kirigakure has a dark past and was known as the 'Village of Bloody Mist' due to its former brutal ninja graduation system. It was the birthplace of legendary figures like the Seven Ninja Swordsmen of the Mist and characters like Zabuza Momochi. Over time, under Mei Terumī's leadership, the village underwent reforms and became more peaceful and prosperous.",
+          url: "https://naruto-shippuden-revolution.weebly.com/uploads/1/8/4/5/18450513/718104511.png",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          name: "Hidden Cloud Village (Kumogakure)",
+          about: "Located in the mountains, Kumogakure is a powerful village with a strong military tradition. Its leader, the Raikage, has always sought to strengthen the village and ensure its superiority. Ninjas from Kumogakure are known for their Lightning Style techniques and their mastery of Raiton. Killer Bee, one of the most skilled Jinchūriki, belongs to this village and trains Naruto in controlling the Kyuubi.",
+          url: "https://pm1.aminoapps.com/6938/97d2efef2c44b0444ec332aa975248ab721a87abr1-360-450v2_00.jpg",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          name: "Hidden Stone Village (Iwagakure)",
+          about: "Iwagakure is known for its use of Earth Style (Doton) and its disciplined, strong-willed ninjas. The leader of the village, the Tsuchikage, has always maintained a strict stance on the country's security. During the Great Ninja Wars, Iwagakure frequently clashed with Konohagakure. One of the most famous ninjas from this village is Deidara, who used explosive clay in combat.",
+          url: "https://pm1.aminoapps.com/7741/bd75a7df66dda90898012dff34eb107baf1f719br4-340-170_00.jpg",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          name: "Hidden Sound Village (Otogakure)",
+          about: "Unlike other villages, Otogakure was not an officially recognized village by the nations. It was created by Orochimaru as a center for experiments and training for his followers. The village served as a base for his plans of revenge against Konoha. Its ninjas were loyal to him and often used forbidden techniques and body modifications.",
+          url: "https://pm1.aminoapps.com/6648/4958d2ee08a45469b836454b6b2c9bb575e7d7a2_hq.jpg",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+      {}
+    );
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.bulkDelete("Villages", null, {});
+  },
+};


### PR DESCRIPTION
**Description**
This PR introduces functionality to fetch all villages from the backend with pagination support.

**Main Changes**

 **Add Village Fetching:**

- Implements the API call to retrieve all villages.
- Adds pagination to the village fetching logic to optimize performance.

**Checklist Before Merging**

-  Village fetching implemented correctly.
-  Pagination works as expected.